### PR TITLE
api example for getting transactions from addresses

### DIFF
--- a/blockchain_downloader.py
+++ b/blockchain_downloader.py
@@ -78,14 +78,13 @@ def get_tx_from_addr(address):
             dat.close()
             for tx in txs:
                 txlist.append(tx["hash"].encode('ascii'))
-                print(txlist[-1])
             offset += 50
         except:
             pass
 
         if len(txlist) == n_tx:
             break
-        print("Progress:", len(txlist), "/", n_tx)
+        print("Progress (if it gets 'stuck' wait a minute or two):", len(txlist), "/", n_tx)
         
     return txlist
 


### PR DESCRIPTION
Script usage (all the stuff at the bottom of the file) will have to change if this is to be integrated. can be done by adding an extra argument for addresses (ex. blockchain_downloader.py addr [address]) or differentiating between base58 (address) and hex (transaction). Or differentiating by length.